### PR TITLE
因为增加了BGM按钮导致header标签长度过长 修改为简练文字

### DIFF
--- a/front/src/lang/cn.js
+++ b/front/src/lang/cn.js
@@ -2,13 +2,13 @@ export default {
   header: {
     index: '首页',
     about: '关于',
-    cheaters: '外挂公示',
-    report: '举报作弊',
+    cheaters: '公示',
+    report: '举报',
     signin: '登录',
     signup: '注册',
     signout: '注销',
     daily: 'ban日报',
-    dashboard: '管理后台',
+    dashboard: '后台',
   },
   footer: {
     author: '由 mygoare 开发',


### PR DESCRIPTION
因为增加了BGM按钮导致header标签长度过长 修改为简练文字